### PR TITLE
Add dependabot config file for the Sketch Plugin

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    version_requirement_updates: "increase_versions"
+    default_labels:
+      - "dependabot"
+    allowed_updates:
+      - match:
+          update_type: "all"


### PR DESCRIPTION
## Card

https://trello.com/c/I0BgRx6N/568-1-elements-wordpress-plugin-keep-dependencies-up-to-date-using-dependabot

## Context

We want to add dependabot to the repo so that all the things stay up to date.

## Change

This adds a dependabot configuration file (as explained here: https://dependabot.com/docs/config-file/ ) and we've validated this configuration file using [the online validator](https://dependabot.com/docs/config-file/validator/).

We're going to merge this PR into master so that dependabot can pick up the configuration file and start opening its own PR's

## CC

cc: @envato/extensions 